### PR TITLE
Add planner input changes

### DIFF
--- a/app/agent/planner.py
+++ b/app/agent/planner.py
@@ -7,9 +7,10 @@ import re
 from copy import deepcopy
 from typing import Any
 
+from app.data.planner_input import build_planner_input as _build_raw_planner_input
 from app.llm import get_llm_client
 from app.prompts import render_prompt
-from app.schemas import AnalysisPlan, CompactSchemaColumn, CompactSchemaContext, CompactSchemaRelation
+from app.schemas import AnalysisPlan, CompactSchemaColumn, CompactSchemaContext, CompactSchemaRelation, PlannerInput
 
 
 _MAX_PROMPT_RELATIONS = 4
@@ -132,6 +133,7 @@ def _coerce_relation(relation: dict[str, Any]) -> CompactSchemaRelation:
 def _render_plan_prompt(
     *,
     query: str,
+    planner_input_json: dict[str, Any] | None = None,
     schema_context_summary: dict[str, Any],
     failure_summary: str = "",
     current_plan: dict[str, Any] | None = None,
@@ -140,10 +142,35 @@ def _render_plan_prompt(
     return render_prompt(
         template_name,
         query=query,
+        planner_input_json=json.dumps(planner_input_json, indent=2) if planner_input_json else "",
         schema_context_json=json.dumps(schema_context_summary, indent=2),
         failure_summary=failure_summary,
         current_plan_json=json.dumps(current_plan or {}, indent=2),
     )
+
+
+def _planner_input_for_state(state: dict[str, Any]) -> dict[str, Any] | None:
+    existing = state.get("planner_input")
+    if isinstance(existing, dict):
+        if existing.get("sources") or existing.get("relationships"):
+            return existing
+        return None
+
+    source_ids = list(state.get("source_ids") or [])
+    if not source_ids:
+        return None
+
+    try:
+        planner_input = _build_raw_planner_input(state["query"], source_ids=source_ids)
+    except Exception:
+        return None
+
+    payload = planner_input.model_dump()
+    if not payload.get("sources") and not payload.get("relationships"):
+        return None
+
+    state["planner_input"] = payload
+    return payload
 
 
 def build_compact_schema_context(dataset_context: dict[str, Any], question: str) -> dict[str, Any]:
@@ -183,12 +210,17 @@ def build_compact_schema_context(dataset_context: dict[str, Any], question: str)
 def plan_analysis(state: dict[str, Any]) -> dict[str, Any]:
     """Return the planner-authored full workflow plan."""
 
+    planner_input = _planner_input_for_state(state)
     schema_context_summary = state.get("schema_context_summary") or build_compact_schema_context(
         state.get("dataset_context", {}),
         state["query"],
     )
     state["schema_context_summary"] = schema_context_summary
-    prompt = _render_plan_prompt(query=state["query"], schema_context_summary=schema_context_summary)
+    prompt = _render_plan_prompt(
+        query=state["query"],
+        planner_input_json=planner_input,
+        schema_context_summary=schema_context_summary,
+    )
     result = get_llm_client().generate_json(prompt, schema=AnalysisPlan)
     parsed = result if isinstance(result, AnalysisPlan) else AnalysisPlan.model_validate(result)
     state["current_plan"] = parsed.model_dump()
@@ -200,6 +232,7 @@ def plan_analysis(state: dict[str, Any]) -> dict[str, Any]:
 def replan_analysis(state: dict[str, Any]) -> dict[str, Any]:
     """Return one revised workflow plan after failure."""
 
+    planner_input = _planner_input_for_state(state)
     schema_context_summary = state.get("schema_context_summary") or build_compact_schema_context(
         state.get("dataset_context", {}),
         state["query"],
@@ -207,6 +240,7 @@ def replan_analysis(state: dict[str, Any]) -> dict[str, Any]:
     state["schema_context_summary"] = schema_context_summary
     prompt = _render_plan_prompt(
         query=state["query"],
+        planner_input_json=planner_input,
         schema_context_summary=schema_context_summary,
         failure_summary=state.get("failure_summary", ""),
         current_plan=state.get("current_plan"),
@@ -232,9 +266,16 @@ def plan_compiled_query(state: dict[str, Any]) -> dict[str, Any]:
     return plan_analysis(state)
 
 
+def build_planner_input(query: str, source_ids: list[str] | None = None) -> PlannerInput:
+    """Build the raw-schema planner contract for attached uploads."""
+
+    return _build_raw_planner_input(query, source_ids=source_ids)
+
+
 __all__ = [
     "_schema_subset_for_question",
     "build_compact_schema_context",
+    "build_planner_input",
     "get_llm_client",
     "plan_analysis",
     "plan_compiled_query",

--- a/app/agent/state.py
+++ b/app/agent/state.py
@@ -13,6 +13,7 @@ class AnalysisState(TypedDict, total=False):
     query: str
     source_ids: list[str]
     dataset_context: dict[str, Any]
+    planner_input: dict[str, Any] | None
     schema_context_summary: dict[str, Any]
     current_plan: dict[str, Any] | None
     current_step_index: int
@@ -39,6 +40,7 @@ def create_initial_state(query: str, source_ids: list[str] | None = None) -> Ana
         query=query,
         source_ids=list(source_ids or []),
         dataset_context={},
+        planner_input=None,
         schema_context_summary={},
         current_plan=None,
         current_step_index=0,

--- a/app/data/planner_input.py
+++ b/app/data/planner_input.py
@@ -1,0 +1,355 @@
+"""Build the raw-schema planner input from persisted upload facts."""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from pathlib import Path
+import re
+from typing import Any
+
+import pandas as pd
+
+from app.data.registry import (
+    get_source_columns,
+    get_source_links,
+    get_source_records,
+    get_source_relations,
+    load_relation_frames,
+)
+from app.schemas import PlannerColumn, PlannerInput, PlannerRelationship, PlannerRelationshipKey, PlannerSource, PlannerTable
+
+
+_SYSTEM_COLUMNS = {"record_id", "parent_record_id", "ordinal"}
+_SUPPORTED_SOURCE_FORMATS = {"csv", "tsv", "json"}
+_COUNT_ONLY_AGGREGATIONS = ["count"]
+_MEASURE_AGGREGATIONS = ["count", "sum", "avg", "min", "max"]
+
+
+def _source_description(metadata: dict[str, Any]) -> str | None:
+    for key in ("description", "source_description"):
+        value = metadata.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _raw_relation_name(relation: dict[str, Any], source_name: str) -> str:
+    lineage = relation.get("lineage") or {}
+    raw_name = lineage.get("raw_name")
+    if isinstance(raw_name, str) and raw_name.strip():
+        return raw_name.strip()
+
+    stem = Path(source_name).stem
+    json_path = lineage.get("json_path")
+    if isinstance(json_path, str) and json_path and json_path != "$":
+        return f"{stem}.{json_path}"
+    return stem
+
+
+def _column_display_name(column: dict[str, Any], duplicate_originals: Counter[str]) -> str:
+    normalized = column["column_name"]
+    if normalized in _SYSTEM_COLUMNS:
+        return normalized
+
+    original = str(column.get("original_name") or normalized)
+    source_path = str(column.get("source_path") or original)
+    if "." in source_path and duplicate_originals[original] > 1:
+        return source_path
+    return original
+
+
+def _is_unique_non_null(series: pd.Series | None) -> bool:
+    if series is None:
+        return False
+    if series.isna().any():
+        return False
+    return bool(len(series) > 0 and series.nunique(dropna=False) == len(series))
+
+
+def _is_identifier_column(column: dict[str, Any], series: pd.Series | None) -> bool:
+    candidates = [
+        str(column.get("column_name") or ""),
+        str(column.get("original_name") or ""),
+        str(column.get("source_path") or ""),
+    ]
+    lowered = [candidate.strip().lower() for candidate in candidates if candidate]
+    if any(value == "id" or value.endswith("_id") or value.endswith(".id") for value in lowered):
+        return True
+    if not _is_unique_non_null(series):
+        return False
+
+    family = str(column.get("type_family") or "unknown")
+    if family not in {"string", "unknown"}:
+        return False
+
+    key_like_tokens = {"key", "code", "uuid", "guid", "identifier", "reference", "ref", "number", "num", "no"}
+    tokenized = {
+        token
+        for candidate in lowered
+        for token in re.split(r"[^a-z0-9]+", candidate)
+        if token
+    }
+    return bool(tokenized & key_like_tokens)
+
+
+def _is_time_column(column: dict[str, Any]) -> bool:
+    if column.get("type_family") == "datetime":
+        return True
+    candidates = [
+        str(column.get("column_name") or ""),
+        str(column.get("original_name") or ""),
+        str(column.get("source_path") or ""),
+    ]
+    lowered = " ".join(candidate.lower() for candidate in candidates if candidate)
+    return any(token in lowered for token in ("date", "time", "timestamp")) or any(
+        candidate.strip().lower().endswith("_at") for candidate in candidates if candidate
+    )
+
+
+def _semantic_role(column: dict[str, Any], series: pd.Series | None) -> str:
+    if column["column_name"] in _SYSTEM_COLUMNS:
+        return "identifier"
+    if _is_identifier_column(column, series):
+        return "identifier"
+    if _is_time_column(column):
+        return "time"
+
+    family = str(column.get("type_family") or "unknown")
+    if family == "boolean":
+        return "boolean"
+    if family == "number":
+        return "measure"
+    if family == "string":
+        return "dimension"
+    return "unknown"
+
+
+def _allowed_aggregations(role: str) -> list[str]:
+    if role == "measure":
+        return list(_MEASURE_AGGREGATIONS)
+    if role in {"identifier", "time", "dimension", "boolean"}:
+        return list(_COUNT_ONLY_AGGREGATIONS)
+    return []
+
+
+def _derive_grain(table_name: str, identifier_columns: list[str]) -> str:
+    if identifier_columns:
+        primary = identifier_columns[0]
+        if primary.lower().endswith("_id"):
+            entity = primary[: -len("_id")].replace("_", " ").strip()
+            if entity:
+                return f"Approximately one row per {entity}"
+        return f"Rows can be keyed by {primary}"
+    return f"Rows represent records in {table_name}"
+
+
+def _derive_table_purpose(table_name: str, grain: str, parent_relation: str | None) -> str:
+    if parent_relation:
+        return f"{grain}. This table captures nested records linked to a parent table."
+    return f"{grain}. This table captures records for {table_name}."
+
+
+def _keys_unique(frame: pd.DataFrame | None, columns: list[str]) -> bool:
+    if frame is None or not columns:
+        return False
+    if any(column not in frame.columns for column in columns):
+        return False
+    subset = frame[columns]
+    if subset.isna().any().any():
+        return False
+    return bool(len(subset) > 0 and len(subset.drop_duplicates()) == len(subset))
+
+
+def _cardinality_for_link(
+    left_frame: pd.DataFrame | None,
+    right_frame: pd.DataFrame | None,
+    join_keys: list[dict[str, str]],
+) -> str:
+    left_columns = [row["left_column"] for row in join_keys if row.get("left_column")]
+    right_columns = [row["right_column"] for row in join_keys if row.get("right_column")]
+    left_unique = _keys_unique(left_frame, left_columns)
+    right_unique = _keys_unique(right_frame, right_columns)
+    if left_unique and right_unique:
+        return "one_to_one"
+    if left_unique and not right_unique:
+        return "one_to_many"
+    if not left_unique and right_unique:
+        return "many_to_one"
+    return "unknown"
+
+
+def _join_safety(link_type: str, cardinality: str) -> str:
+    if link_type == "parent_child" or cardinality == "one_to_many":
+        return "aggregate_child_before_join"
+    if cardinality in {"one_to_one", "many_to_one"}:
+        return "safe_raw_join"
+    return "manual_review_required"
+
+
+def _confirmed_by(link_type: str, is_explicit: bool) -> str:
+    if link_type == "parent_child":
+        return "json_nesting"
+    if is_explicit:
+        return "user_link"
+    return "registry_rule"
+
+
+def _build_planner_columns(
+    raw_table_name: str,
+    relation_columns: list[dict[str, Any]],
+    frame: pd.DataFrame | None,
+) -> tuple[list[PlannerColumn], dict[str, str]]:
+    duplicate_originals = Counter(
+        str(column.get("original_name") or column["column_name"])
+        for column in relation_columns
+        if column["column_name"] not in _SYSTEM_COLUMNS
+    )
+    planner_columns: list[PlannerColumn] = []
+    normalized_to_raw: dict[str, str] = {}
+
+    for column in relation_columns:
+        normalized_name = column["column_name"]
+        raw_name = _column_display_name(column, duplicate_originals)
+        normalized_to_raw[normalized_name] = raw_name
+
+        if normalized_name in _SYSTEM_COLUMNS:
+            continue
+
+        series = frame[normalized_name] if frame is not None and normalized_name in frame.columns else None
+        role = _semantic_role(column, series)
+        allowed_aggregations = _allowed_aggregations(role)
+        planner_columns.append(
+            PlannerColumn(
+                table_name=raw_table_name,
+                column_name=raw_name,
+                data_type=column["dtype"],
+                nullable=bool(column["nullable"]),
+                source_path=column.get("source_path"),
+                source_description=None,
+                semantic_role=role,
+                filterable=role != "unknown",
+                groupable=role in {"identifier", "time", "dimension", "boolean"},
+                aggregatable=bool(allowed_aggregations),
+                allowed_aggregations=allowed_aggregations,
+            )
+        )
+
+    return planner_columns, normalized_to_raw
+
+
+def build_planner_input(query: str, source_ids: list[str] | None = None) -> PlannerInput:
+    """Return the full raw-schema planner contract for the requested uploads."""
+
+    source_rows = get_source_records(source_ids)
+    relation_rows = get_source_relations(source_ids)
+    column_rows = get_source_columns(source_ids)
+    link_rows = get_source_links(source_ids)
+    frames = load_relation_frames(source_ids)
+
+    relations_by_source: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    columns_by_relation: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    normalized_to_raw_table: dict[str, str] = {}
+    normalized_to_raw_column: dict[str, dict[str, str]] = {}
+
+    for relation in relation_rows:
+        relations_by_source[relation["source_id"]].append(relation)
+    for column in column_rows:
+        columns_by_relation[column["relation_name"]].append(column)
+
+    planner_sources: list[PlannerSource] = []
+    for source in source_rows:
+        source_format = str(source["source_format"]).lower()
+        if source_format not in _SUPPORTED_SOURCE_FORMATS:
+            raise ValueError(f"Unsupported planner source format: {source_format}")
+
+        tables: list[PlannerTable] = []
+        source_relations = relations_by_source.get(source["source_id"], [])
+        source_relations.sort(key=lambda row: (not row["is_primary"], _raw_relation_name(row, source["source_name"]).lower()))
+
+        for relation in source_relations:
+            raw_table_name = _raw_relation_name(relation, source["source_name"])
+            normalized_to_raw_table[relation["relation_name"]] = raw_table_name
+
+            relation_columns = sorted(columns_by_relation.get(relation["relation_name"], []), key=lambda row: row["ordinal"])
+            frame = frames.get(relation["relation_name"])
+            planner_columns, column_name_map = _build_planner_columns(
+                raw_table_name,
+                relation_columns,
+                frame,
+            )
+            normalized_to_raw_column[relation["relation_name"]] = column_name_map
+
+            identifier_columns = [column.column_name for column in planner_columns if column.semantic_role == "identifier"]
+            time_columns = [column.column_name for column in planner_columns if column.semantic_role == "time"]
+            measure_columns = [column.column_name for column in planner_columns if column.semantic_role == "measure"]
+            dimension_columns = [column.column_name for column in planner_columns if column.semantic_role == "dimension"]
+            filterable_columns = [column.column_name for column in planner_columns if column.filterable]
+            groupable_columns = [column.column_name for column in planner_columns if column.groupable]
+            aggregatable_columns = [column.column_name for column in planner_columns if column.aggregatable]
+            grain = _derive_grain(raw_table_name, identifier_columns)
+
+            tables.append(
+                PlannerTable(
+                    source_id=source["source_id"],
+                    table_name=raw_table_name,
+                    kind="table",
+                    row_count=relation["row_count"],
+                    source_description=None,
+                    grain=grain,
+                    table_purpose=_derive_table_purpose(raw_table_name, grain, relation["parent_relation"]),
+                    identifier_columns=identifier_columns,
+                    time_columns=time_columns,
+                    measure_columns=measure_columns,
+                    dimension_columns=dimension_columns,
+                    filterable_columns=filterable_columns,
+                    groupable_columns=groupable_columns,
+                    aggregatable_columns=aggregatable_columns,
+                    columns=planner_columns,
+                )
+            )
+
+        planner_sources.append(
+            PlannerSource(
+                source_id=source["source_id"],
+                source_name=source["source_name"],
+                source_format=source_format,
+                source_description=_source_description(source["metadata"]),
+                tables=tables,
+            )
+        )
+
+    planner_relationships: list[PlannerRelationship] = []
+    for link in link_rows:
+        left_relation_name = link["left_relation_name"]
+        right_relation_name = link["right_relation_name"]
+        cardinality = _cardinality_for_link(
+            frames.get(left_relation_name),
+            frames.get(right_relation_name),
+            link["join_keys"],
+        )
+        planner_relationships.append(
+            PlannerRelationship(
+                left_source_id=link["left_source_id"],
+                left_table=normalized_to_raw_table.get(left_relation_name, left_relation_name),
+                right_source_id=link["right_source_id"],
+                right_table=normalized_to_raw_table.get(right_relation_name, right_relation_name),
+                relationship_type="parent_child" if link["link_type"] == "parent_child" else "explicit",
+                cardinality=cardinality,
+                join_keys=[
+                    PlannerRelationshipKey(
+                        left_column=normalized_to_raw_column.get(left_relation_name, {}).get(row["left_column"], row["left_column"]),
+                        right_column=normalized_to_raw_column.get(right_relation_name, {}).get(row["right_column"], row["right_column"]),
+                    )
+                    for row in link["join_keys"]
+                ],
+                join_safety=_join_safety(link["link_type"], cardinality),
+                confirmed_by=_confirmed_by(link["link_type"], link["is_explicit"]),
+            )
+        )
+
+    return PlannerInput(
+        user_query=query,
+        execution_dialect="duckdb",
+        sources=planner_sources,
+        relationships=planner_relationships,
+    )

--- a/app/data/registry.py
+++ b/app/data/registry.py
@@ -24,17 +24,6 @@ _RELATIONS_TABLE = "__planera_registry_source_relations"
 _COLUMNS_TABLE = "__planera_registry_source_columns"
 _LINKS_TABLE = "__planera_registry_source_links"
 _SYSTEM_COLUMNS = {"record_id", "parent_record_id", "ordinal"}
-_SEMANTIC_ALIAS_LEXICON: dict[str, list[str]] = {
-    "owner": ["agent", "rep", "representative", "sales rep", "assignee"],
-    "manager": ["manager", "lead", "supervisor", "team lead"],
-    "regional_office": ["region", "regional office", "office", "territory"],
-    "account_id": ["account", "customer", "client", "account identifier"],
-    "deal_id": ["deal", "opportunity", "opportunity identifier"],
-    "deal_value": ["revenue", "deal size", "amount", "value"],
-    "stage": ["status stage", "pipeline stage"],
-    "segment": ["customer segment", "market segment"],
-    "pipeline_velocity_days": ["pipeline velocity", "cycle time", "sales cycle length"],
-}
 
 
 @dataclass(frozen=True)
@@ -250,11 +239,6 @@ def _semantic_hints(column_name: str, original_name: str = "", source_path: str 
             hints.add(f"{base} id")
             hints.add(f"{base} identifier")
 
-    for key, aliases in _SEMANTIC_ALIAS_LEXICON.items():
-        key_tokens = set(_split_identifier(key))
-        if column_name == key or key_tokens.issubset(set(tokens)):
-            hints.update(aliases)
-
     return sorted(hint for hint in hints if hint)
 
 
@@ -362,11 +346,13 @@ def _coerce_frame_types(frame: pd.DataFrame) -> pd.DataFrame:
     return coerced.convert_dtypes()
 
 
-def _rename_system_columns(frame: pd.DataFrame) -> pd.DataFrame:
+def _rename_uploaded_columns(frame: pd.DataFrame) -> tuple[pd.DataFrame, dict[str, dict[str, str]]]:
     renamed = frame.copy()
     next_names: dict[str, str] = {}
+    column_paths: dict[str, dict[str, str]] = {}
     for column in renamed.columns:
-        safe_name = _safe_identifier(str(column))
+        raw_name = str(column)
+        safe_name = _safe_identifier(raw_name)
         candidate = safe_name
         if candidate in _SYSTEM_COLUMNS:
             candidate = f"{candidate}_value"
@@ -375,7 +361,11 @@ def _rename_system_columns(frame: pd.DataFrame) -> pd.DataFrame:
             candidate = f"{safe_name}_{counter}"
             counter += 1
         next_names[column] = candidate
-    return renamed.rename(columns=next_names)
+        column_paths[candidate] = {
+            "original_name": raw_name,
+            "source_path": raw_name,
+        }
+    return renamed.rename(columns=next_names), column_paths
 
 
 def _ensure_record_id(frame: pd.DataFrame) -> pd.DataFrame:
@@ -480,10 +470,12 @@ def _read_uploaded_frame(filename: str, content: bytes) -> pd.DataFrame:
     try:
         if suffix == ".csv":
             return pd.read_csv(buffer)
+        if suffix == ".tsv":
+            return pd.read_csv(buffer, sep="\t")
     except Exception as exc:  # pragma: no cover - pandas errors vary
         raise ValueError(f"Could not parse {filename} as a structured text dataset.") from exc
 
-    raise ValueError("Only CSV and JSON uploads are currently supported.")
+    raise ValueError("Only CSV, TSV, and JSON uploads are currently supported.")
 
 
 def _build_uploaded_asset(package: SourcePackage) -> UploadedAsset:
@@ -650,20 +642,22 @@ def _build_child_relation_name(primary_relation_name: str, path_segments: tuple[
     return f"{primary_relation_name}__{suffix}"
 
 
-def _ingest_csv_source(filename: str, content: bytes, source_id: str | None = None) -> SourcePackage:
+def _ingest_delimited_source(
+    filename: str,
+    content: bytes,
+    *,
+    source_format: str,
+    source_id: str | None = None,
+) -> SourcePackage:
     safe_name = Path(filename or "upload.csv").name
-    frame = _ensure_record_id(_rename_system_columns(_read_uploaded_frame(safe_name, content)))
+    raw_frame = _read_uploaded_frame(safe_name, content)
+    renamed_frame, column_paths = _rename_uploaded_columns(raw_frame)
+    frame = _ensure_record_id(renamed_frame)
     frame = _coerce_frame_types(frame)
     source_id = source_id or _short_id("source")
     source_slug = _slugify(Path(safe_name).stem)
     relation_name = _build_primary_relation_name(source_slug, source_id)
-    column_paths = {
-        str(column): {
-            "original_name": str(column),
-            "source_path": str(column),
-        }
-        for column in frame.columns
-    }
+    column_paths["record_id"] = {"original_name": "record_id", "source_path": "record_id"}
     relation = _schema_relation_for_frame(
         relation_name=relation_name,
         source_id=source_id,
@@ -673,7 +667,7 @@ def _ingest_csv_source(filename: str, content: bytes, source_id: str | None = No
         is_primary=True,
         parent_relation=None,
         join_keys=[],
-        lineage={"format": "csv", "json_path": "$"},
+        lineage={"format": source_format, "json_path": "$"},
         column_paths=column_paths,
     )
     return SourcePackage(
@@ -681,14 +675,22 @@ def _ingest_csv_source(filename: str, content: bytes, source_id: str | None = No
         source_name=safe_name,
         source_slug=source_slug,
         source_kind="upload",
-        source_format="csv",
+        source_format=source_format,
         origin="Workspace upload",
         file_name=safe_name,
-        file_type=_derive_file_type(safe_name, "csv"),
+        file_type=_derive_file_type(safe_name, source_format),
         size_bytes=len(content),
         raw_payload=content,
         relations=[RelationPackage(relation=relation, frame=frame)],
     )
+
+
+def _ingest_csv_source(filename: str, content: bytes, source_id: str | None = None) -> SourcePackage:
+    return _ingest_delimited_source(filename, content, source_format="csv", source_id=source_id)
+
+
+def _ingest_tsv_source(filename: str, content: bytes, source_id: str | None = None) -> SourcePackage:
+    return _ingest_delimited_source(filename, content, source_format="tsv", source_id=source_id)
 
 
 def _ingest_json_source(filename: str, content: bytes, source_id: str | None = None) -> SourcePackage:
@@ -894,7 +896,7 @@ def ensure_builtin_sources() -> None:
 
 
 def ingest_source(filename: str, content: bytes, *, source_id: str | None = None) -> UploadedAsset:
-    """Persist a CSV/JSON upload into the registry and return its UI summary."""
+    """Persist a CSV/TSV/JSON upload into the registry and return its UI summary."""
 
     safe_name = Path(filename or "upload.csv").name
     suffix = Path(safe_name).suffix.lower()
@@ -902,8 +904,10 @@ def ingest_source(filename: str, content: bytes, *, source_id: str | None = None
         package = _ingest_json_source(safe_name, content, source_id=source_id)
     elif suffix == ".csv":
         package = _ingest_csv_source(safe_name, content, source_id=source_id)
+    elif suffix == ".tsv":
+        package = _ingest_tsv_source(safe_name, content, source_id=source_id)
     else:
-        raise ValueError("Only CSV and JSON uploads are currently supported.")
+        raise ValueError("Only CSV, TSV, and JSON uploads are currently supported.")
     conn = _connect_registry(read_only=False)
     try:
         _persist_source_package(conn, package)
@@ -913,6 +917,135 @@ def ingest_source(filename: str, content: bytes, *, source_id: str | None = None
 
     clear_semantic_context_cache()
     return _build_uploaded_asset(package)
+
+
+def get_source_records(source_ids: list[str] | None = None) -> list[dict[str, Any]]:
+    """Return persisted source records for the requested scope."""
+
+    conn = _connect_registry(read_only=True)
+    try:
+        filter_sql, params = _source_filter_sql(source_ids)
+        rows = conn.execute(
+            f"""
+            SELECT source_id, source_name, source_format, origin, file_name, file_type, metadata_json
+            FROM {_SOURCES_TABLE}
+            {filter_sql}
+            ORDER BY source_id
+            """,
+            params,
+        ).fetchall()
+        return [
+            {
+                "source_id": source_id,
+                "source_name": source_name,
+                "source_format": source_format,
+                "origin": origin,
+                "file_name": file_name,
+                "file_type": file_type,
+                "metadata": json.loads(metadata_json or "{}"),
+            }
+            for source_id, source_name, source_format, origin, file_name, file_type, metadata_json in rows
+        ]
+    finally:
+        conn.close()
+
+
+def get_source_relations(source_ids: list[str] | None = None) -> list[dict[str, Any]]:
+    """Return persisted relation facts for the requested scope."""
+
+    conn = _connect_registry(read_only=True)
+    try:
+        filter_sql, params = _source_filter_sql(source_ids)
+        rows = conn.execute(
+            f"""
+            SELECT relation_name, source_id, kind, is_primary, parent_relation, row_count, grain, lineage_json
+            FROM {_RELATIONS_TABLE}
+            {filter_sql}
+            ORDER BY source_id, is_primary DESC, relation_name
+            """,
+            params,
+        ).fetchall()
+        return [
+            {
+                "relation_name": relation_name,
+                "source_id": source_id,
+                "kind": kind,
+                "is_primary": bool(is_primary),
+                "parent_relation": parent_relation,
+                "row_count": int(row_count),
+                "grain": grain or "",
+                "lineage": json.loads(lineage_json or "{}"),
+            }
+            for relation_name, source_id, kind, is_primary, parent_relation, row_count, grain, lineage_json in rows
+        ]
+    finally:
+        conn.close()
+
+
+def get_source_columns(source_ids: list[str] | None = None) -> list[dict[str, Any]]:
+    """Return persisted column facts for the requested scope."""
+
+    conn = _connect_registry(read_only=True)
+    try:
+        filter_sql, params = _source_filter_sql(source_ids)
+        rows = conn.execute(
+            f"""
+            SELECT source_id, relation_name, ordinal, column_name, dtype, type_family, original_name, source_path, nullable
+            FROM {_COLUMNS_TABLE}
+            {filter_sql}
+            ORDER BY source_id, relation_name, ordinal
+            """,
+            params,
+        ).fetchall()
+        return [
+            {
+                "source_id": source_id,
+                "relation_name": relation_name,
+                "ordinal": int(ordinal),
+                "column_name": column_name,
+                "dtype": dtype,
+                "type_family": type_family,
+                "original_name": original_name or column_name,
+                "source_path": source_path or column_name,
+                "nullable": bool(nullable),
+            }
+            for source_id, relation_name, ordinal, column_name, dtype, type_family, original_name, source_path, nullable in rows
+        ]
+    finally:
+        conn.close()
+
+
+def get_source_links(source_ids: list[str] | None = None) -> list[dict[str, Any]]:
+    """Return confirmed stored links for the requested scope."""
+
+    conn = _connect_registry(read_only=True)
+    try:
+        filter_sql, params = _link_filter_sql(source_ids)
+        rows = conn.execute(
+            f"""
+            SELECT left_source_id, left_relation_name, right_source_id, right_relation_name, link_type,
+                   is_explicit, join_keys_json, metadata_json
+            FROM {_LINKS_TABLE}
+            {filter_sql}
+            ORDER BY left_source_id, left_relation_name, right_relation_name
+            """,
+            params,
+        ).fetchall()
+        return [
+            {
+                "left_source_id": left_source_id,
+                "left_relation_name": left_relation_name,
+                "right_source_id": right_source_id,
+                "right_relation_name": right_relation_name,
+                "link_type": link_type,
+                "is_explicit": bool(is_explicit),
+                "join_keys": json.loads(join_keys_json or "[]"),
+                "metadata": json.loads(metadata_json or "{}"),
+            }
+            for left_source_id, left_relation_name, right_source_id, right_relation_name, link_type, is_explicit, join_keys_json, metadata_json in rows
+        ]
+    finally:
+        conn.close()
 
 
 def delete_source(source_id: str) -> None:

--- a/app/prompts/planner_plan.j2
+++ b/app/prompts/planner_plan.j2
@@ -2,12 +2,16 @@ You are the planner in a bounded analytics workflow.
 
 You receive:
 - the user's natural-language question
+{% if planner_input_json %}
+- a raw planner-input contract derived from uploaded structured data
+{% else %}
 - a compact schema/context summary derived from uploaded structured data
+{% endif %}
 
 Your job:
 - return the full ordered analysis plan in one shot
 - Do not write SQL
-- use only relations, columns, and join paths present in the schema/context summary
+- use only relations, columns, and join paths present in the provided schema contract
 - if the question cannot be fully answered, say so explicitly in `unsupported_requirements`
 
 Rules:
@@ -53,5 +57,10 @@ Return JSON in this shape:
 User question:
 {{ query }}
 
+{% if planner_input_json %}
+Raw planner input:
+{{ planner_input_json }}
+{% else %}
 Compact schema/context summary:
 {{ schema_context_json }}
+{% endif %}

--- a/app/prompts/planner_replan.j2
+++ b/app/prompts/planner_replan.j2
@@ -5,7 +5,7 @@ The previous plan or execution path failed and needs one revised full plan.
 Rules:
 - Return only valid JSON matching the schema.
 - Do not write SQL.
-- Use only relations, columns, and join paths present in the schema/context summary.
+- Use only relations, columns, and join paths present in the provided schema contract.
 - Use the failure summary to avoid repeating the same mistake.
 - If the question is only partially answerable, set `can_answer_fully` to false and explain the gap in `unsupported_requirements`.
 - If the available data can no longer support any safe next step, return zero steps.
@@ -21,5 +21,10 @@ Current plan:
 Failure summary:
 {{ failure_summary }}
 
+{% if planner_input_json %}
+Raw planner input:
+{{ planner_input_json }}
+{% else %}
 Compact schema/context summary:
 {{ schema_context_json }}
+{% endif %}

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -152,6 +152,97 @@ class SchemaManifest(BaseModel):
     views: list[dict[str, Any]] = Field(default_factory=list)
 
 
+PlannerAggregationLiteral = Literal["count", "sum", "avg", "min", "max"]
+
+
+class PlannerRelationshipKey(BaseModel):
+    """One confirmed join key carried into planner input."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    left_column: str = Field(..., min_length=1)
+    right_column: str = Field(..., min_length=1)
+
+
+class PlannerColumn(BaseModel):
+    """Planner-facing raw column metadata."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    table_name: str = Field(..., min_length=1)
+    column_name: str = Field(..., min_length=1)
+    data_type: str = Field(..., min_length=1)
+    nullable: bool = True
+    source_path: str | None = None
+    source_description: str | None = None
+    semantic_role: Literal["identifier", "time", "measure", "dimension", "boolean", "unknown"] = "unknown"
+    filterable: bool = True
+    groupable: bool = True
+    aggregatable: bool = False
+    allowed_aggregations: list[PlannerAggregationLiteral] = Field(default_factory=list)
+
+
+class PlannerTable(BaseModel):
+    """Planner-facing raw table metadata."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    source_id: str = Field(..., min_length=1)
+    table_name: str = Field(..., min_length=1)
+    kind: Literal["table"] = "table"
+    row_count: int = 0
+    source_description: str | None = None
+    grain: str = ""
+    table_purpose: str = ""
+    identifier_columns: list[str] = Field(default_factory=list)
+    time_columns: list[str] = Field(default_factory=list)
+    measure_columns: list[str] = Field(default_factory=list)
+    dimension_columns: list[str] = Field(default_factory=list)
+    filterable_columns: list[str] = Field(default_factory=list)
+    groupable_columns: list[str] = Field(default_factory=list)
+    aggregatable_columns: list[str] = Field(default_factory=list)
+    columns: list[PlannerColumn] = Field(default_factory=list)
+
+
+class PlannerSource(BaseModel):
+    """One attached uploaded source visible to the planner."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    source_id: str = Field(..., min_length=1)
+    source_name: str = Field(..., min_length=1)
+    source_format: Literal["csv", "tsv", "json"]
+    source_description: str | None = None
+    tables: list[PlannerTable] = Field(default_factory=list)
+
+
+class PlannerRelationship(BaseModel):
+    """One confirmed relationship visible to the planner."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    left_source_id: str = Field(..., min_length=1)
+    left_table: str = Field(..., min_length=1)
+    right_source_id: str = Field(..., min_length=1)
+    right_table: str = Field(..., min_length=1)
+    relationship_type: Literal["parent_child", "explicit"]
+    cardinality: Literal["one_to_one", "one_to_many", "many_to_one", "unknown"] = "unknown"
+    join_keys: list[PlannerRelationshipKey] = Field(default_factory=list)
+    join_safety: Literal["safe_raw_join", "aggregate_child_before_join", "manual_review_required"] = "manual_review_required"
+    confirmed_by: Literal["json_nesting", "user_link", "registry_rule"]
+
+
+class PlannerInput(BaseModel):
+    """Full raw-schema planner input built from attached uploads."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    user_query: str = Field(..., min_length=1)
+    execution_dialect: str = Field(..., min_length=1)
+    sources: list[PlannerSource] = Field(default_factory=list)
+    relationships: list[PlannerRelationship] = Field(default_factory=list)
+
+
 class CompactSchemaColumn(BaseModel):
     """Compact field summary shared with the planner, query writer, and analyzer."""
 

--- a/tests/test_agent_contracts.py
+++ b/tests/test_agent_contracts.py
@@ -70,6 +70,7 @@ def test_create_initial_state_exposes_new_workflow_fields() -> None:
     assert state["query"] == "How many orders are overdue?"
     assert state["source_ids"] == ["source_123"]
     assert state["schema_context_summary"] == {}
+    assert state["planner_input"] is None
     assert state["current_plan"] is None
     assert state["stored_outputs"] == {}
     assert state["step_queries"] == {}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -217,16 +217,32 @@ def test_upload_endpoint_profiles_json(client: TestClient) -> None:
     assert payload["asset"]["primaryRelationName"]
 
 
+def test_upload_endpoint_profiles_tsv(client: TestClient) -> None:
+    token = _signup(client, "upload-tsv@example.com")
+    response = client.post(
+        "/uploads",
+        files={"file": ("pipeline.tsv", BytesIO(b"stage\tamount\nopen\t10\nwon\t25\n"), "text/tab-separated-values")},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["asset"]["type"] == "TSV"
+    assert payload["asset"]["rows"] == 2
+    assert payload["asset"]["columns"] == 2
+    assert payload["asset"]["relationCount"] == 1
+
+
 def test_upload_endpoint_rejects_unsupported_file_types(client: TestClient) -> None:
     token = _signup(client, "upload-unsupported@example.com")
     response = client.post(
         "/uploads",
-        files={"file": ("pipeline.tsv", BytesIO(b"stage\tamount\nopen\t10\n"), "text/tab-separated-values")},
+        files={"file": ("pipeline.txt", BytesIO(b"stage amount\nopen 10\n"), "text/plain")},
         headers={"Authorization": f"Bearer {token}"},
     )
 
     assert response.status_code == 400
-    assert response.json()["detail"]["message"] == "Only CSV and JSON uploads are currently supported."
+    assert response.json()["detail"]["message"] == "Only CSV, TSV, and JSON uploads are currently supported."
 
 
 def test_upload_endpoint_migrates_legacy_uploads_table(tmp_path, monkeypatch) -> None:

--- a/tests/test_planner_input.py
+++ b/tests/test_planner_input.py
@@ -1,0 +1,137 @@
+"""Tests for the raw-schema planner input contract."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.agent.planner import build_planner_input
+from app.config import get_settings
+from app.data.registry import clear_source_registry, create_source_link, ingest_source
+from app.data.semantic_model import clear_semantic_context_cache
+
+
+@pytest.fixture(autouse=True)
+def isolated_registry(tmp_path, monkeypatch):
+    monkeypatch.setenv("REGISTRY_PATH", str(tmp_path / "planner_source_registry.duckdb"))
+    get_settings.cache_clear()
+    clear_source_registry()
+    clear_semantic_context_cache()
+    yield
+    clear_source_registry()
+    clear_semantic_context_cache()
+    get_settings.cache_clear()
+
+
+def _table_by_name(planner_input, table_name: str):
+    for source in planner_input.sources:
+        for table in source.tables:
+            if table.table_name == table_name:
+                return table
+    raise AssertionError(f"Table {table_name!r} not found in planner input.")
+
+
+def test_build_planner_input_returns_empty_sources_without_uploads() -> None:
+    planner_input = build_planner_input("What data is available?")
+
+    assert planner_input.execution_dialect == "duckdb"
+    assert planner_input.sources == []
+    assert planner_input.relationships == []
+
+
+def test_csv_planner_input_preserves_raw_table_and_column_names() -> None:
+    asset = ingest_source(
+        "Sales Orders 2024.csv",
+        b"Order ID,Customer Name,Order Value ($)\no1,Ada,120.5\no2,Ben,80.0\n",
+    )
+
+    planner_input = build_planner_input("Which customers spent the most?", [asset.id])
+
+    assert len(planner_input.sources) == 1
+    source = planner_input.sources[0]
+    assert source.source_format == "csv"
+    table = _table_by_name(planner_input, "Sales Orders 2024")
+    assert table.source_id == asset.id
+    assert table.table_name == "Sales Orders 2024"
+    assert {column.column_name for column in table.columns} == {"Order ID", "Customer Name", "Order Value ($)"}
+    assert table.identifier_columns == ["Order ID"]
+    assert table.measure_columns == ["Order Value ($)"]
+    assert table.groupable_columns == ["Order ID", "Customer Name"]
+    assert "semantic_mappings" not in table.model_dump()
+    assert all(column.source_description is None for column in table.columns)
+
+
+def test_tsv_planner_input_keeps_full_schema_without_trimming() -> None:
+    headers = ["Order ID"] + [f"Column {index}" for index in range(1, 23)]
+    row_one = ["o1"] + [str(index) for index in range(1, 23)]
+    row_two = ["o2"] + [str(index + 100) for index in range(1, 23)]
+    payload = ("\t".join(headers) + "\n" + "\t".join(row_one) + "\n" + "\t".join(row_two) + "\n").encode("utf-8")
+    asset = ingest_source("wide.tsv", payload)
+
+    planner_input = build_planner_input("Show me every field.", [asset.id])
+    table = _table_by_name(planner_input, "wide")
+
+    assert planner_input.sources[0].source_format == "tsv"
+    assert len(table.columns) == len(headers)
+    assert {column.column_name for column in table.columns} == set(headers)
+
+
+def test_nested_json_upload_uses_raw_table_names_and_confirmed_relationships() -> None:
+    asset = ingest_source(
+        "orders.json",
+        b'[{"order_id":"o1","customer":{"name":"Ada"},"items":[{"sku":"A1","qty":2},{"sku":"B2","qty":1}]}]',
+    )
+
+    planner_input = build_planner_input("Which items were ordered?", [asset.id])
+    root = _table_by_name(planner_input, "orders")
+    child = _table_by_name(planner_input, "orders.items")
+
+    assert {table.table_name for table in planner_input.sources[0].tables} == {"orders", "orders.items"}
+    assert any(column.column_name == "name" and column.source_path == "customer.name" for column in root.columns)
+    assert {column.column_name for column in child.columns} == {"sku", "qty"}
+
+    relationship = planner_input.relationships[0]
+    assert relationship.left_table == "orders"
+    assert relationship.right_table == "orders.items"
+    assert relationship.relationship_type == "parent_child"
+    assert relationship.cardinality == "one_to_many"
+    assert relationship.join_safety == "aggregate_child_before_join"
+    assert relationship.confirmed_by == "json_nesting"
+    assert relationship.join_keys[0].left_column == "record_id"
+    assert relationship.join_keys[0].right_column == "parent_record_id"
+
+
+def test_unrelated_sources_do_not_auto_join_on_shared_column_names() -> None:
+    customers = ingest_source("customers.csv", b"customer_id,name\nc1,Ada\nc2,Ben\n")
+    orders = ingest_source("orders.csv", b"customer_id,amount\nc1,100\nc1,50\n")
+
+    planner_input = build_planner_input("Which customers spent the most?", [customers.id, orders.id])
+
+    assert len(planner_input.sources) == 2
+    assert planner_input.relationships == []
+
+
+def test_explicit_source_links_are_exposed_as_confirmed_relationships() -> None:
+    customers = ingest_source("customers.csv", b"customer_id,name\nc1,Ada\nc2,Ben\n")
+    orders = ingest_source("orders.csv", b"customer_id,amount\nc1,100\nc1,50\n")
+    create_source_link(customers.primaryRelationName, "customer_id", orders.primaryRelationName, "customer_id")
+
+    planner_input = build_planner_input("Which customers spent the most?", [customers.id, orders.id])
+
+    assert len(planner_input.relationships) == 1
+    relationship = planner_input.relationships[0]
+    assert relationship.relationship_type == "explicit"
+    assert relationship.confirmed_by == "user_link"
+    assert relationship.cardinality == "one_to_many"
+    assert relationship.join_keys[0].left_column == "customer_id"
+    assert relationship.join_keys[0].right_column == "customer_id"
+
+
+def test_same_filename_sources_remain_separate_by_source_id() -> None:
+    first = ingest_source("orders.csv", b"order_id,amount\no1,100\n", source_id="source_a")
+    second = ingest_source("orders.csv", b"order_id,amount\no2,250\n", source_id="source_b")
+
+    planner_input = build_planner_input("Compare both uploads.", [first.id, second.id])
+
+    assert len(planner_input.sources) == 2
+    assert {source.source_id for source in planner_input.sources} == {"source_a", "source_b"}
+    assert all(len(source.tables) == 1 for source in planner_input.sources)


### PR DESCRIPTION
## What changed

This PR improves the input we give to the planner.

We added a new planner input builder that reads uploaded data and gives the planner a clearer view of the available tables, columns, and relationships. It keeps the raw table and column names from the uploaded files, adds useful metadata like column roles and allowed aggregations, and includes confirmed joins when they are known.

We also updated the planner and replan prompts to use this new planner input when it is available. On top of that, we added tests for CSV, TSV, and JSON uploads, relationship handling, and planner input behavior to make sure this flow works as expected.
